### PR TITLE
upde  railway.json

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -6,7 +6,7 @@
     "buildCommand": "echo 'Building...' && python -m pip install -r requirements.txt"
   },
   "deploy": {
-    "startCommand": "cd shop && python manage.py collectstatic --noinput && python manage.py migrate && gunicorn shop.wsgi --log-file -",
+    "startCommand": "python shop/manage.py collectstatic --noinput && python shop/manage.py migrate && gunicorn --chdir shop shop.wsgi --log-file -",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
J'ai remplacé cd shop && ... par une approche plus robuste : Utilisation de python shop/manage.py au lieu de cd shop && python manage.py Ajout de l'option --chdir shop à gunicorn au lieu d'utiliser cd Cette approche est plus fiable car elle n'utilise pas la commande cd qui semble causer des problèmes dans votre environnement de déploiement. Redéployez votre application avec cette nouvelle configuration et cela devrait résoudre l'erreur.